### PR TITLE
refactor(security-config): remove duplicate filter and alarm

### DIFF
--- a/config/security-config.yaml
+++ b/config/security-config.yaml
@@ -613,12 +613,6 @@ cloudWatch:
           metricNamespace: CloudTrailMetrics
           metricName: UnencryptedFilesystemCreatedCount
           metricValue: "1"
-        - filterName: "{{ AcceleratorPrefix }}-IgnoreAuthorizationFailureMetric"
-          logGroupName: {{ CloudTrailLogGroup }}
-          filterPattern: "{($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")}"
-          metricNamespace: CloudTrailMetrics
-          metricName: IgnoreAuthorizationFailureCount
-          metricValue: "1"
         - filterName: "{{ AcceleratorPrefix }}-IgnoreConsoleSignInWithoutMfaMetric"
           logGroupName: {{ CloudTrailLogGroup }}
           filterPattern: "{($.eventName=\"ConsoleLogin\") && ($.additionalEventData.MFAUsed !=\"Yes\")}"
@@ -847,17 +841,6 @@ cloudWatch:
           alarmDescription: Alarms when one or more API calls are made to create an Unencrypted filesystem (i.e. EFS) (in any account, any region of your AWS Organization).
           snsTopicName: SecurityHigh
           metricName: UnencryptedFilesystemCreatedCount
-          namespace: CloudTrailMetrics
-          comparisonOperator: GreaterThanOrEqualToThreshold
-          evaluationPeriods: 1
-          period: 300
-          statistic: Sum
-          threshold: 1
-          treatMissingData: notBreaching
-        - alarmName: "{{ AcceleratorPrefix }}-IGNORE-AWS-Authorization-Failure"
-          alarmDescription: Alarms when one or more unauthorized API calls are made (in any account, any region of your AWS Organization).
-          snsTopicName: SecurityIgnore
-          metricName: IgnoreAuthorizationFailureCount
           namespace: CloudTrailMetrics
           comparisonOperator: GreaterThanOrEqualToThreshold
           evaluationPeriods: 1


### PR DESCRIPTION
*Description of changes:*

Duplicate metric filter and alarm for CIS rules:

https://github.com/aws-samples/landing-zone-accelerator-on-aws-for-tse-se/blob/7f64c4a7dbf82d0abb1cce4d314a63fa9ef6704f/config/security-config.yaml#L403-L409

Reduce duplicate costs for Metric Filter and duplicate alarms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
